### PR TITLE
Improved downloading, added -e *, fixed donation message not displaying properly when the twist.moe donation goal is already met

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,7 @@ $ twist-dl -a "yuyushiki" -e 1-12             # Download everything from episode
 $ twist-dl -a "yuyushiki" -e 12 -o "./yyshk"  # Download 12th episode into "yyshk" folder
 $ twist-dl -a "yuyushiki" -e 1,3              # Download only the 1st and 3rd episode
 $ twist-dl -a "yuyushiki" -e 1,5-8            # Download 1st episode and episodes 5 to 8
+$ twist-dl -a "yuyushiki" -e *                # Download every episode
 $ twist-dl https://twist.moe/a/yuyushiki/12   # Download 12th episode
 ```
 

--- a/index.js
+++ b/index.js
@@ -1,5 +1,5 @@
 const
-    { red, yellow, cyan } = require('ansi-colors'),
+    { red, yellow, cyan, green } = require('ansi-colors'),
     crypto = require('crypto-js'),  // Perhaps translate into nodev10 crypto?
     aes = require('crypto-js/aes'),
     fetch = require('node-fetch'),
@@ -66,13 +66,18 @@ Options:
             name: 'episodes', message: `Select episodes: (${getTitle(selectedAnime)})`, /*limit: 24,*/
             choices: Object.keys(sources)
         })).run()).map(x => sources[x])
-        
+
         // use console.error so we don't write to stdout but stderr (in case of piping)
         console.error(`\n  ${cyan('twist-dl')} is currently under developement, if any problems occur, please ${red('submit an issue')} on the GitHub's repo.`)
         console.error(`  ${red('Remember: ')} If you have some money to spare, donate it to twist.moe so they can the servers up and running!`)
         try{
             const donation = await getJSON('/api/donation')
-            console.error(`\n  They're ${red(Math.round((donation.remaining + Number.EPSILON)*100)/100 + '$ short')} on money this month.\n  To donate, please visit https://twist.moe/\n`)
+            const donationAmount = Math.round((donation.remaining + Number.EPSILON)*100)/100;
+            if(donationAmount >= 0){
+                console.error(`\n  They're ${red('$'+donationAmount + ' short')} on money this month.\n  To donate, please visit https://twist.moe/\n`)
+            }else{
+                console.error(`\n  They're ${green('$'+-donationAmount + ' over')} the donation goal this month.\n  To donate, please visit https://twist.moe/\n`)
+            }
         }catch(err){}
         console.error(`  ${yellow(getTitle(selectedAnime))}\n`)
         ensureDirectoryExists(path.resolve(process.cwd(), argv.output || ''))

--- a/index.js
+++ b/index.js
@@ -66,7 +66,7 @@ Options:
             name: 'episodes', message: `Select episodes: (${getTitle(selectedAnime)})`, /*limit: 24,*/
             choices: Object.keys(sources)
         })).run()).map(x => sources[x])
-
+        
         // use console.error so we don't write to stdout but stderr (in case of piping)
         console.error(`\n  ${cyan('twist-dl')} is currently under developement, if any problems occur, please ${red('submit an issue')} on the GitHub's repo.`)
         console.error(`  ${red('Remember: ')} If you have some money to spare, donate it to twist.moe so they can the servers up and running!`)
@@ -170,10 +170,15 @@ function downloadAndPipeIntoStdout(url){
 }
 
 function getArrayOfEpisodes(source, input){
-    const rawEpisodes = input.split(',').map(x => parseRange(x.trim())).reduce((acc,val) => acc.concat(...val), [])
-    const uniqueEpisodes = uniqueArray(rawEpisodes.sort()).map(x => `Episode ${x}`)
-
-    return uniqueEpisodes.map(x => source[x])
+    let episodeArray;
+    if(input != "*"){
+        const rawEpisodes = input.split(',').map(x => parseRange(x.trim())).reduce((acc,val) => acc.concat(...val), [])
+        const uniqueEpisodes = uniqueArray(rawEpisodes.sort()).map(x => `Episode ${x}`)
+        episodeArray = uniqueEpisodes.map(x => source[x]);
+    }else{
+        episodeArray = Object.values(source);
+    }
+    return episodeArray;
 
     function parseRange(range){
         const [ start, end ] = range.split(`-`)


### PR DESCRIPTION
Improved downloading by fixing a bug that caused the file to not fully download. When the user's internet connect was disrupted, the file would be counted as fully downloaded even when incomplete. 
To fix this, there's now a check to make sure the file has actually fully downloaded. If it hasn't, it will keep trying until it has.

If a file is already fully downloaded, it won't forcibly download it again.

Passing "-e *" will now download all episodes.

Instead of the donation message displaying "$-100 short" when the donation goal is $100 over, it will now display "$100 over the donation goal". The dollar sign is also now in front of the dollar amount instead of behind it.